### PR TITLE
Fix build under windows and msvc

### DIFF
--- a/src/wes.c
+++ b/src/wes.c
@@ -1,5 +1,5 @@
 /*
-GL_MANGLE(gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
+gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
 Contact:    lachlan.ts@gmail.com
 Copyright (C) 2009  Lachlan Tychsen - Smith aka Adventus
 
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "wes_matrix.h"
 
 #if defined(_WIN32)
+	#define NOMINMAX
     #include <windows.h>
 
 #ifdef WINAPI_FAMILY
@@ -53,8 +54,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
     }
 #else
     #define dlopen(A, B)    LoadLibrary(A)
-    #define dlsym(A, B)     GetProcAddress((HINSTANCE__*) A, B)
-    #define dlclose(A)      FreeLibrary((HINSTANCE__*) A)
+    #define dlsym(A, B)     GetProcAddress((HMODULE) A, B)
+    #define dlclose(A)      FreeLibrary((HMODULE) A)
 #endif
 #else
     #define __GNU_SOURCE
@@ -227,24 +228,24 @@ wes_init(const char *gles2)
     int i;
     void** ptr;
 
-    LOGI("Start wes_init()");
+    LOGI("Start wes_init()\n");
 
     wes_gl = (gles2lib_t*) malloc(sizeof(gles2lib_t));
     if (wes_gl == NULL)
     {
-        LOGE("Could not load Allocate mem: %s", gles2);
+        LOGE("Could not load Allocate mem: %s\n", gles2);
     }
 
-	LOGI("Memory alloc wes_init()");
+	LOGI("Memory alloc wes_init()\n");
 #if !defined XASH_SDL && !defined REF_DLL
 	wes_libhandle = dlopen(gles2, RTLD_NOW | RTLD_LOCAL);//RTLD_LAZY | RTLD_GLOBAL);
 
 	if (wes_libhandle == NULL)
     {
-        LOGE("Could not load OpenGL ES 2 runtime library: %s", gles2);
+        LOGE("Could not load OpenGL ES 2 runtime library: %s\n", gles2);
     }
 #endif
-	LOGI("lib loaded wes_init()");
+	LOGI("lib loaded wes_init()\n");
 
     ptr = (void**) wes_gl;
     for(i = 0; i != WES_OGLESV2_FUNCTIONCOUNT+1; i++)
@@ -257,26 +258,27 @@ wes_init(const char *gles2)
 		void* pfunc = (void*) dlsym(wes_libhandle, glfuncnames[i]);
 #endif
         if (pfunc == NULL)
-			LOGE("Could not find %s in %s", glfuncnames[i], gles2 );
-		else LOGI("Loaded %s", glfuncnames[i]);
+			LOGE("Could not find %s in %s\n", glfuncnames[i], gles2 );
+		else
+			LOGI("Loaded %s\n", glfuncnames[i]);
 
         *ptr++ = pfunc;
     }
 
-	LOGI("methods loaded wes_init()");
+	LOGI("methods loaded wes_init()\n");
 
     wes_shader_init();
-	LOGI("wes_shader_init()");
+	LOGI("wes_shader_init()\n");
 
     wes_matrix_init();
-	LOGI("wes_matrix_init()");
+	LOGI("wes_matrix_init()\n");
 
     wes_begin_init();
-	LOGI("wes_begin_init()");
+	LOGI("wes_begin_init()\n");
 
     wes_state_init();
 
-    LOGI("Finished wes_init()");
+    LOGI("Finished wes_init()\n");
 }
 
 GLvoid

--- a/src/wes.h
+++ b/src/wes.h
@@ -32,10 +32,20 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define WES_MULTITEX_NUM        4
 #define WES_FACE_NUM            2
 
-#ifdef WES_MANGLE_PREPEND
-#define GL_MANGLE( x ) p##x
+#ifndef WES_APIENTRY
+#if defined(_WIN32)
+#define WES_APIENTRY __stdcall
 #else
-#define GL_MANGLE( x ) x
+#define WES_APIENTRY
+#endif
+#endif
+
+#ifdef WES_MANGLE_PREPEND
+#define GL_MANGLE( x ) WES_APIENTRY p##x
+#define GL_MANGLE_NAME( x ) p##x
+#else
+#define GL_MANGLE( x ) WES_APIENTRY x
+#define GL_MANGLE_NAME( x ) x
 #endif
 
 #define LOG_TAG "gl-wes-v2"
@@ -50,10 +60,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG,__VA_ARGS__)
 #else
 
-#define LOGI(...) printf("I: \n"__VA_ARGS__)
-#define LOGD(...) if(DEBUG_NANO) printf("D: \n"__VA_ARGS__)
-#define LOGE(...) printf("E: \n"__VA_ARGS__)
-#define LOGW(...) printf("W: \n"__VA_ARGS__)
+#define LOGI(...) printf("I: "__VA_ARGS__)
+#define LOGD(...) if(DEBUG_NANO) printf("D: "__VA_ARGS__)
+#define LOGE(...) printf("E: "__VA_ARGS__)
+#define LOGW(...) printf("W: "__VA_ARGS__)
 
 #endif
 
@@ -84,154 +94,156 @@ typedef void ( *GL_DEBUG_PROC_ARB )( unsigned int source, unsigned int type, uns
 
 struct gles2lib_s
 {
-     void         (*glActiveTexture)(GLenum texture) S;
-     void         (*glAttachShader)(GLuint program, GLuint shader) S;
-     void         (*glBindAttribLocation)(GLuint program, GLuint index, const char* name) S;
-     void         (*glBindBuffer)(GLenum target, GLuint buffer) S;
-     void         (*glBindFramebuffer)(GLenum target, GLuint framebuffer) S;
-     void         (*glBindRenderbuffer)(GLenum target, GLuint renderbuffer) S;
-     void         (*glBindTexture)(GLenum target, GLuint texture) S;
-     void         (*glBlendColor)(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) S;
-     void         (*glBlendEquation)( GLenum mode ) S;
-     void         (*glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha) S;
-     void         (*glBlendFunc)(GLenum sfactor, GLenum dfactor) S;
-     void         (*glBlendFuncSeparate)(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha) S;
-     void         (*glBufferData)(GLenum target, GLsizeiptr size, const void* data, GLenum usage) S;
-     void         (*glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void* data) S;
-     GLenum       (*glCheckFramebufferStatus)(GLenum target) S;
-     void         (*glClear)(GLbitfield mask) S;
-     void         (*glClearColor)(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) S;
-     void         (*glClearDepthf)(GLclampf depth) S;
-     void         (*glClearStencil)(GLint s) S;
-     void         (*glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) S;
-     void         (*glCompileShader)(GLuint shader) S;
-     void         (*glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void* data) S;
-     void         (*glCompressedTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, const void* data) S;
-     void         (*glCopyTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border) S;
-     void         (*glCopyTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height) S;
-     GLuint       (*glCreateProgram)(void) S;
-     GLuint       (*glCreateShader)(GLenum type) S;
-     void         (*glCullFace)(GLenum mode) S;
-     void         (*glDeleteBuffers)(GLsizei n, const GLuint* buffers) S;
-     void         (*glDeleteFramebuffers)(GLsizei n, const GLuint* framebuffers) S;
-     void         (*glDeleteTextures)(GLsizei n, const GLuint* textures) S;
-     void         (*glDeleteProgram)(GLuint program) S;
-     void         (*glDeleteRenderbuffers)(GLsizei n, const GLuint* renderbuffers) S;
-     void         (*glDeleteShader)(GLuint shader) S;
-     void         (*glDetachShader)(GLuint program, GLuint shader) S;
-     void         (*glDepthFunc)(GLenum func) S;
-     void         (*glDepthMask)(GLboolean flag) S;
-     void         (*glDepthRangef)(GLclampf zNear, GLclampf zFar) S;
-     void         (*glDisable)(GLenum cap) S;
-     void         (*glDisableVertexAttribArray)(GLuint index) S;
-     void         (*glDrawArrays)(GLenum mode, GLint first, GLsizei count) S;
-     void         (*glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void* indices) S;
-     void         (*glDrawRangeElements )( GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const GLvoid *indices ) S;
-     void         (*glEnable)(GLenum cap) S;
-     void         (*glEnableVertexAttribArray)(GLuint index) S;
-     void         (*glFinish)(void) S;
-     void         (*glFlush)(void) S;
-     void         (*glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer) S;
-     void         (*glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level) S;
-     void         (*glFrontFace)(GLenum mode) S;
-     void         (*glGenBuffers)(GLsizei n, GLuint* buffers) S;
-     void         (*glGenerateMipmap)(GLenum target) S;
-     void         (*glGenFramebuffers)(GLsizei n, GLuint* framebuffers) S;
-     void         (*glGenRenderbuffers)(GLsizei n, GLuint* renderbuffers) S;
-     void         (*glGenTextures)(GLsizei n, GLuint* textures) S;
-     void         (*glGetActiveAttrib)(GLuint program, GLuint index, GLsizei bufsize, GLsizei* length, GLint* size, GLenum* type, char* name) S;
-     void         (*glGetActiveUniform)(GLuint program, GLuint index, GLsizei bufsize, GLsizei* length, GLint* size, GLenum* type, char* name) S;
-     void         (*glGetAttachedShaders)(GLuint program, GLsizei maxcount, GLsizei* count, GLuint* shaders) S;
-     int          (*glGetAttribLocation)(GLuint program, const char* name) S;
-     void         (*glGetBooleanv)(GLenum pname, GLboolean* params) S;
-     void         (*glGetBufferParameteriv)(GLenum target, GLenum pname, GLint* params) S;
-     GLenum       (*glGetError)(void) S;
-     void         (*glGetFloatv)(GLenum pname, GLfloat* params) S;
-     void         (*glGetFramebufferAttachmentParameteriv)(GLenum target, GLenum attachment, GLenum pname, GLint* params) S;
-     void         (*glGetIntegerv)(GLenum pname, GLint* params) S;
-     void         (*glGetProgramiv)(GLuint program, GLenum pname, GLint* params) S;
-     void         (*glGetProgramInfoLog)(GLuint program, GLsizei bufsize, GLsizei* length, char* infolog) S;
-     void         (*glGetRenderbufferParameteriv)(GLenum target, GLenum pname, GLint* params) S;
-     void         (*glGetShaderiv)(GLuint shader, GLenum pname, GLint* params) S;
-     void         (*glGetShaderInfoLog)(GLuint shader, GLsizei bufsize, GLsizei* length, char* infolog) S;
-     void         (*glGetShaderPrecisionFormat)(GLenum shadertype, GLenum precisiontype, GLint* range, GLint* precision) S;
-     void         (*glGetShaderSource)(GLuint shader, GLsizei bufsize, GLsizei* length, char* source) S;
-     const GLubyte* (*glGetString)(GLenum name) S;
-     void         (*glGetTexParameterfv)(GLenum target, GLenum pname, GLfloat* params) S;
-     void         (*glGetTexParameteriv)(GLenum target, GLenum pname, GLint* params) S;
-     void         (*glGetUniformfv)(GLuint program, GLint location, GLfloat* params) S;
-     void         (*glGetUniformiv)(GLuint program, GLint location, GLint* params) S;
-     int          (*glGetUniformLocation)(GLuint program, const char* name) S;
-     void         (*glGetVertexAttribfv)(GLuint index, GLenum pname, GLfloat* params) S;
-     void         (*glGetVertexAttribiv)(GLuint index, GLenum pname, GLint* params) S;
-     void         (*glGetVertexAttribPointerv)(GLuint index, GLenum pname, void** pointer) S;
-     void         (*glHint)(GLenum target, GLenum mode) S;
-     GLboolean    (*glIsBuffer)(GLuint buffer) S;
-     GLboolean    (*glIsEnabled)(GLenum cap) S;
-     GLboolean    (*glIsFramebuffer)(GLuint framebuffer) S;
-     GLboolean    (*glIsProgram)(GLuint program) S;
-     GLboolean    (*glIsRenderbuffer)(GLuint renderbuffer) S;
-     GLboolean    (*glIsShader)(GLuint shader) S;
-     GLboolean    (*glIsTexture)(GLuint texture) S;
-     void         (*glLineWidth)(GLfloat width) S;
-     void         (*glLinkProgram)(GLuint program) S;
-     void         (*glPixelStorei)(GLenum pname, GLint param) S;
-     void         (*glPolygonOffset)(GLfloat factor, GLfloat units) S;
-     void         (*glReadPixels)(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, void* pixels) S;
-     void         (*glReleaseShaderCompiler)(void) S;
-     void         (*glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height) S;
-     void         (*glSampleCoverage)(GLclampf value, GLboolean invert) S;
-     void         (*glScissor)(GLint x, GLint y, GLsizei width, GLsizei height) S;
-     void         (*glShaderBinary)(GLint n, const GLuint* shaders, GLenum binaryformat, const void* binary, GLint length) S;
-     void         (*glShaderSource)(GLuint shader, GLsizei count, const char** string, const GLint* length) S;
-     void         (*glStencilFunc)(GLenum func, GLint ref, GLuint mask) S;
-     void         (*glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask) S;
-     void         (*glStencilMask)(GLuint mask) S;
-     void         (*glStencilMaskSeparate)(GLenum face, GLuint mask) S;
-     void         (*glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass) S;
-     void         (*glStencilOpSeparate)(GLenum face, GLenum fail, GLenum zfail, GLenum zpass) S;
-     void         (*glTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void* pixels) S;
-     void         (*glTexParameterf)(GLenum target, GLenum pname, GLfloat param) S;
-     void         (*glTexParameterfv)(GLenum target, GLenum pname, const GLfloat* params) S;
-     void         (*glTexParameteri)(GLenum target, GLenum pname, GLint param) S;
-     void         (*glTexParameteriv)(GLenum target, GLenum pname, const GLint* params) S;
-     void         (*glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void* pixels) S;
-     void         (*glUniform1f)(GLint location, GLfloat x) S;
-     void         (*glUniform1fv)(GLint location, GLsizei count, const GLfloat* v) S;
-     void         (*glUniform1i)(GLint location, GLint x) S;
-     void         (*glUniform1iv)(GLint location, GLsizei count, const GLint* v) S;
-     void         (*glUniform2f)(GLint location, GLfloat x, GLfloat y) S;
-     void         (*glUniform2fv)(GLint location, GLsizei count, const GLfloat* v) S;
-     void         (*glUniform2i)(GLint location, GLint x, GLint y) S;
-     void         (*glUniform2iv)(GLint location, GLsizei count, const GLint* v) S;
-     void         (*glUniform3f)(GLint location, GLfloat x, GLfloat y, GLfloat z) S;
-     void         (*glUniform3fv)(GLint location, GLsizei count, const GLfloat* v) S;
-     void         (*glUniform3i)(GLint location, GLint x, GLint y, GLint z) S;
-     void         (*glUniform3iv)(GLint location, GLsizei count, const GLint* v) S;
-     void         (*glUniform4f)(GLint location, GLfloat x, GLfloat y, GLfloat z, GLfloat w) S;
-     void         (*glUniform4fv)(GLint location, GLsizei count, const GLfloat* v) S;
-     void         (*glUniform4i)(GLint location, GLint x, GLint y, GLint z, GLint w) S;
-     void         (*glUniform4iv)(GLint location, GLsizei count, const GLint* v) S;
-     void         (*glUniformMatrix2fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) S;
-     void         (*glUniformMatrix3fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) S;
-     void         (*glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) S;
-     void         (*glUseProgram)(GLuint program) S;
-     void         (*glValidateProgram)(GLuint program) S;
-     void         (*glVertexAttrib1f)(GLuint indx, GLfloat x) S;
-     void         (*glVertexAttrib1fv)(GLuint indx, const GLfloat* values) S;
-     void         (*glVertexAttrib2f)(GLuint indx, GLfloat x, GLfloat y) S;
-     void         (*glVertexAttrib2fv)(GLuint indx, const GLfloat* values) S;
-     void         (*glVertexAttrib3f)(GLuint indx, GLfloat x, GLfloat y, GLfloat z) S;
-     void         (*glVertexAttrib3fv)(GLuint indx, const GLfloat* values) S;
-     void         (*glVertexAttrib4f)(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w) S;
-     void         (*glVertexAttrib4fv)(GLuint indx, const GLfloat* values) S;
-     void         (*glVertexAttribPointer)(GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void* ptr) S;
-     void         (*glViewport)(GLint x, GLint y, GLsizei width, GLsizei height) S;
-     void         (*glDebugMessageControlKHR)( GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint* ids, GLboolean enabled ) S;
-     void         (*glDebugMessageInsertKHR)( GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const char* buf ) S;
-     void         (*glDebugMessageCallbackKHR)( GL_DEBUG_PROC_KHR callback, void* userParam ) S;
-     GLuint       (*glGetDebugMessageLogKHR)( GLuint count, GLsizei bufsize, GLenum* sources, GLenum* types, GLuint* ids, GLuint* severities, GLsizei* lengths, char* messageLog ) S;
+     void         (WES_APIENTRY *glActiveTexture)(GLenum texture) S;
+     void         (WES_APIENTRY *glAttachShader)(GLuint program, GLuint shader) S;
+     void         (WES_APIENTRY *glBindAttribLocation)(GLuint program, GLuint index, const char* name) S;
+     void         (WES_APIENTRY *glBindBuffer)(GLenum target, GLuint buffer) S;
+     void         (WES_APIENTRY *glBindFramebuffer)(GLenum target, GLuint framebuffer) S;
+     void         (WES_APIENTRY *glBindRenderbuffer)(GLenum target, GLuint renderbuffer) S;
+     void         (WES_APIENTRY *glBindTexture)(GLenum target, GLuint texture) S;
+     void         (WES_APIENTRY *glBlendColor)(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) S;
+     void         (WES_APIENTRY *glBlendEquation)( GLenum mode ) S;
+     void         (WES_APIENTRY *glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha) S;
+     void         (WES_APIENTRY *glBlendFunc)(GLenum sfactor, GLenum dfactor) S;
+     void         (WES_APIENTRY *glBlendFuncSeparate)(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha) S;
+     void         (WES_APIENTRY *glBufferData)(GLenum target, GLsizeiptr size, const void* data, GLenum usage) S;
+     void         (WES_APIENTRY *glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void* data) S;
+     GLenum       (WES_APIENTRY *glCheckFramebufferStatus)(GLenum target) S;
+     void         (WES_APIENTRY *glClear)(GLbitfield mask) S;
+     void         (WES_APIENTRY *glClearColor)(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) S;
+     void         (WES_APIENTRY *glClearDepthf)(GLclampf depth) S;
+     void         (WES_APIENTRY *glClearStencil)(GLint s) S;
+     void         (WES_APIENTRY *glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) S;
+     void         (WES_APIENTRY *glCompileShader)(GLuint shader) S;
+     void         (WES_APIENTRY *glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void* data) S;
+     void         (WES_APIENTRY *glCompressedTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, const void* data) S;
+     void         (WES_APIENTRY *glCopyTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border) S;
+     void         (WES_APIENTRY *glCopyTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height) S;
+     GLuint       (WES_APIENTRY *glCreateProgram)(void) S;
+     GLuint       (WES_APIENTRY *glCreateShader)(GLenum type) S;
+     void         (WES_APIENTRY *glCullFace)(GLenum mode) S;
+     void         (WES_APIENTRY *glDeleteBuffers)(GLsizei n, const GLuint* buffers) S;
+     void         (WES_APIENTRY *glDeleteFramebuffers)(GLsizei n, const GLuint* framebuffers) S;
+     void         (WES_APIENTRY *glDeleteTextures)(GLsizei n, const GLuint* textures) S;
+     void         (WES_APIENTRY *glDeleteProgram)(GLuint program) S;
+     void         (WES_APIENTRY *glDeleteRenderbuffers)(GLsizei n, const GLuint* renderbuffers) S;
+     void         (WES_APIENTRY *glDeleteShader)(GLuint shader) S;
+     void         (WES_APIENTRY *glDetachShader)(GLuint program, GLuint shader) S;
+     void         (WES_APIENTRY *glDepthFunc)(GLenum func) S;
+     void         (WES_APIENTRY *glDepthMask)(GLboolean flag) S;
+     void         (WES_APIENTRY *glDepthRangef)(GLclampf zNear, GLclampf zFar) S;
+     void         (WES_APIENTRY *glDisable)(GLenum cap) S;
+     void         (WES_APIENTRY *glDisableVertexAttribArray)(GLuint index) S;
+     void         (WES_APIENTRY *glDrawArrays)(GLenum mode, GLint first, GLsizei count) S;
+     void         (WES_APIENTRY *glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void* indices) S;
+     void         (WES_APIENTRY *glDrawRangeElements )( GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const GLvoid *indices ) S;
+     void         (WES_APIENTRY *glEnable)(GLenum cap) S;
+     void         (WES_APIENTRY *glEnableVertexAttribArray)(GLuint index) S;
+     void         (WES_APIENTRY *glFinish)(void) S;
+     void         (WES_APIENTRY *glFlush)(void) S;
+     void         (WES_APIENTRY *glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer) S;
+     void         (WES_APIENTRY *glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level) S;
+     void         (WES_APIENTRY *glFrontFace)(GLenum mode) S;
+     void         (WES_APIENTRY *glGenBuffers)(GLsizei n, GLuint* buffers) S;
+     void         (WES_APIENTRY *glGenerateMipmap)(GLenum target) S;
+     void         (WES_APIENTRY *glGenFramebuffers)(GLsizei n, GLuint* framebuffers) S;
+     void         (WES_APIENTRY *glGenRenderbuffers)(GLsizei n, GLuint* renderbuffers) S;
+     void         (WES_APIENTRY *glGenTextures)(GLsizei n, GLuint* textures) S;
+     void         (WES_APIENTRY *glGetActiveAttrib)(GLuint program, GLuint index, GLsizei bufsize, GLsizei* length, GLint* size, GLenum* type, char* name) S;
+     void         (WES_APIENTRY *glGetActiveUniform)(GLuint program, GLuint index, GLsizei bufsize, GLsizei* length, GLint* size, GLenum* type, char* name) S;
+     void         (WES_APIENTRY *glGetAttachedShaders)(GLuint program, GLsizei maxcount, GLsizei* count, GLuint* shaders) S;
+     int          (WES_APIENTRY *glGetAttribLocation)(GLuint program, const char* name) S;
+     void         (WES_APIENTRY *glGetBooleanv)(GLenum pname, GLboolean* params) S;
+     void         (WES_APIENTRY *glGetBufferParameteriv)(GLenum target, GLenum pname, GLint* params) S;
+     GLenum       (WES_APIENTRY *glGetError)(void) S;
+     void         (WES_APIENTRY *glGetFloatv)(GLenum pname, GLfloat* params) S;
+     void         (WES_APIENTRY *glGetFramebufferAttachmentParameteriv)(GLenum target, GLenum attachment, GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetIntegerv)(GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetProgramiv)(GLuint program, GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetProgramInfoLog)(GLuint program, GLsizei bufsize, GLsizei* length, char* infolog) S;
+     void         (WES_APIENTRY *glGetRenderbufferParameteriv)(GLenum target, GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetShaderiv)(GLuint shader, GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetShaderInfoLog)(GLuint shader, GLsizei bufsize, GLsizei* length, char* infolog) S;
+     void         (WES_APIENTRY *glGetShaderPrecisionFormat)(GLenum shadertype, GLenum precisiontype, GLint* range, GLint* precision) S;
+     void         (WES_APIENTRY *glGetShaderSource)(GLuint shader, GLsizei bufsize, GLsizei* length, char* source) S;
+     const GLubyte* (WES_APIENTRY *glGetString)(GLenum name) S;
+     void         (WES_APIENTRY *glGetTexParameterfv)(GLenum target, GLenum pname, GLfloat* params) S;
+     void         (WES_APIENTRY *glGetTexParameteriv)(GLenum target, GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetUniformfv)(GLuint program, GLint location, GLfloat* params) S;
+     void         (WES_APIENTRY *glGetUniformiv)(GLuint program, GLint location, GLint* params) S;
+     int          (WES_APIENTRY *glGetUniformLocation)(GLuint program, const char* name) S;
+     void         (WES_APIENTRY *glGetVertexAttribfv)(GLuint index, GLenum pname, GLfloat* params) S;
+     void         (WES_APIENTRY *glGetVertexAttribiv)(GLuint index, GLenum pname, GLint* params) S;
+     void         (WES_APIENTRY *glGetVertexAttribPointerv)(GLuint index, GLenum pname, void** pointer) S;
+     void         (WES_APIENTRY *glHint)(GLenum target, GLenum mode) S;
+     GLboolean    (WES_APIENTRY *glIsBuffer)(GLuint buffer) S;
+     GLboolean    (WES_APIENTRY *glIsEnabled)(GLenum cap) S;
+     GLboolean    (WES_APIENTRY *glIsFramebuffer)(GLuint framebuffer) S;
+     GLboolean    (WES_APIENTRY *glIsProgram)(GLuint program) S;
+     GLboolean    (WES_APIENTRY *glIsRenderbuffer)(GLuint renderbuffer) S;
+     GLboolean    (WES_APIENTRY *glIsShader)(GLuint shader) S;
+     GLboolean    (WES_APIENTRY *glIsTexture)(GLuint texture) S;
+     void         (WES_APIENTRY *glLineWidth)(GLfloat width) S;
+     void         (WES_APIENTRY *glLinkProgram)(GLuint program) S;
+     void         (WES_APIENTRY *glPixelStorei)(GLenum pname, GLint param) S;
+     void         (WES_APIENTRY *glPolygonOffset)(GLfloat factor, GLfloat units) S;
+     void         (WES_APIENTRY *glReadPixels)(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, void* pixels) S;
+     void         (WES_APIENTRY *glReleaseShaderCompiler)(void) S;
+     void         (WES_APIENTRY *glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height) S;
+     void         (WES_APIENTRY *glSampleCoverage)(GLclampf value, GLboolean invert) S;
+     void         (WES_APIENTRY *glScissor)(GLint x, GLint y, GLsizei width, GLsizei height) S;
+     void         (WES_APIENTRY *glShaderBinary)(GLint n, const GLuint* shaders, GLenum binaryformat, const void* binary, GLint length) S;
+     void         (WES_APIENTRY *glShaderSource)(GLuint shader, GLsizei count, const char** string, const GLint* length) S;
+     void         (WES_APIENTRY *glStencilFunc)(GLenum func, GLint ref, GLuint mask) S;
+     void         (WES_APIENTRY *glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask) S;
+     void         (WES_APIENTRY *glStencilMask)(GLuint mask) S;
+     void         (WES_APIENTRY *glStencilMaskSeparate)(GLenum face, GLuint mask) S;
+     void         (WES_APIENTRY *glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass) S;
+     void         (WES_APIENTRY *glStencilOpSeparate)(GLenum face, GLenum fail, GLenum zfail, GLenum zpass) S;
+     void         (WES_APIENTRY *glTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void* pixels) S;
+     void         (WES_APIENTRY *glTexParameterf)(GLenum target, GLenum pname, GLfloat param) S;
+     void         (WES_APIENTRY *glTexParameterfv)(GLenum target, GLenum pname, const GLfloat* params) S;
+     void         (WES_APIENTRY *glTexParameteri)(GLenum target, GLenum pname, GLint param) S;
+     void         (WES_APIENTRY *glTexParameteriv)(GLenum target, GLenum pname, const GLint* params) S;
+     void         (WES_APIENTRY *glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void* pixels) S;
+     void         (WES_APIENTRY *glUniform1f)(GLint location, GLfloat x) S;
+     void         (WES_APIENTRY *glUniform1fv)(GLint location, GLsizei count, const GLfloat* v) S;
+     void         (WES_APIENTRY *glUniform1i)(GLint location, GLint x) S;
+     void         (WES_APIENTRY *glUniform1iv)(GLint location, GLsizei count, const GLint* v) S;
+     void         (WES_APIENTRY *glUniform2f)(GLint location, GLfloat x, GLfloat y) S;
+     void         (WES_APIENTRY *glUniform2fv)(GLint location, GLsizei count, const GLfloat* v) S;
+     void         (WES_APIENTRY *glUniform2i)(GLint location, GLint x, GLint y) S;
+     void         (WES_APIENTRY *glUniform2iv)(GLint location, GLsizei count, const GLint* v) S;
+     void         (WES_APIENTRY *glUniform3f)(GLint location, GLfloat x, GLfloat y, GLfloat z) S;
+     void         (WES_APIENTRY *glUniform3fv)(GLint location, GLsizei count, const GLfloat* v) S;
+     void         (WES_APIENTRY *glUniform3i)(GLint location, GLint x, GLint y, GLint z) S;
+     void         (WES_APIENTRY *glUniform3iv)(GLint location, GLsizei count, const GLint* v) S;
+     void         (WES_APIENTRY *glUniform4f)(GLint location, GLfloat x, GLfloat y, GLfloat z, GLfloat w) S;
+     void         (WES_APIENTRY *glUniform4fv)(GLint location, GLsizei count, const GLfloat* v) S;
+     void         (WES_APIENTRY *glUniform4i)(GLint location, GLint x, GLint y, GLint z, GLint w) S;
+     void         (WES_APIENTRY *glUniform4iv)(GLint location, GLsizei count, const GLint* v) S;
+     void         (WES_APIENTRY *glUniformMatrix2fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) S;
+     void         (WES_APIENTRY *glUniformMatrix3fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) S;
+     void         (WES_APIENTRY *glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) S;
+     void         (WES_APIENTRY *glUseProgram)(GLuint program) S;
+     void         (WES_APIENTRY *glValidateProgram)(GLuint program) S;
+     void         (WES_APIENTRY *glVertexAttrib1f)(GLuint indx, GLfloat x) S;
+     void         (WES_APIENTRY *glVertexAttrib1fv)(GLuint indx, const GLfloat* values) S;
+     void         (WES_APIENTRY *glVertexAttrib2f)(GLuint indx, GLfloat x, GLfloat y) S;
+     void         (WES_APIENTRY *glVertexAttrib2fv)(GLuint indx, const GLfloat* values) S;
+     void         (WES_APIENTRY *glVertexAttrib3f)(GLuint indx, GLfloat x, GLfloat y, GLfloat z) S;
+     void         (WES_APIENTRY *glVertexAttrib3fv)(GLuint indx, const GLfloat* values) S;
+     void         (WES_APIENTRY *glVertexAttrib4f)(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w) S;
+     void         (WES_APIENTRY *glVertexAttrib4fv)(GLuint indx, const GLfloat* values) S;
+     void         (WES_APIENTRY *glVertexAttribPointer)(GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void* ptr) S;
+     void         (WES_APIENTRY *glViewport)(GLint x, GLint y, GLsizei width, GLsizei height) S;
+     void         (WES_APIENTRY *glDebugMessageControlKHR)( GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint* ids, GLboolean enabled ) S;
+     void         (WES_APIENTRY *glDebugMessageInsertKHR)( GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const char* buf ) S;
+     void         (WES_APIENTRY *glDebugMessageCallbackKHR)( GL_DEBUG_PROC_KHR callback, void* userParam ) S;
+     GLuint       (WES_APIENTRY *glGetDebugMessageLogKHR)( GLuint count, GLsizei bufsize, GLenum* sources, GLenum* types, GLuint* ids, GLuint* severities, GLsizei* lengths, char* messageLog ) S;
 };
+
+#undef S
 
 #if !defined (__WINS__)
     #if	defined(__TARGET_FPU_VFP)

--- a/src/wes_begin.c
+++ b/src/wes_begin.c
@@ -337,7 +337,7 @@ GLvoid
 GL_MANGLE(glVertex3f)(GLfloat x, GLfloat y, GLfloat z)
 {
     if (vt_possize > 3){
-	GL_MANGLE(glVertex4f)(x, y, z, 1.0);
+	GL_MANGLE_NAME(glVertex4f)(x, y, z, 1.0);
     } else {
         vt_possize = 3;
         vt_current->x = x;
@@ -356,7 +356,7 @@ GL_MANGLE(glVertex3f)(GLfloat x, GLfloat y, GLfloat z)
 GLvoid
 GL_MANGLE(glVertex3fv)(const GLfloat *v)
 {
-	return GL_MANGLE(glVertex3f)(v[0], v[1], v[2]);
+	GL_MANGLE_NAME(glVertex3f)(v[0], v[1], v[2]);
 }
 /*
 GLvoid GL_MANGLE(glBlendFunc)(GLenum sfactor, GLenum dfactor)
@@ -376,7 +376,7 @@ GLvoid GL_MANGLE(glDepthMask)( GLboolean flag )
 
 GLvoid GL_MANGLE(glShadeModel) (GLenum mode)
 {
-	return;
+
 }
 
 GLvoid GL_MANGLE(glPointSize)( GLfloat size )
@@ -390,7 +390,7 @@ GLvoid
 GL_MANGLE(glVertex2f)(GLfloat x, GLfloat y)
 {
     if (vt_possize > 2) {
-	GL_MANGLE(glVertex3f)(x, y, 0.0);
+	GL_MANGLE_NAME(glVertex3f)(x, y, 0.0);
     } else {
         vt_possize = 2;
         vt_current->x = x;
@@ -420,7 +420,7 @@ GLvoid
 GL_MANGLE(glTexCoord3f)(GLfloat s, GLfloat t, GLfloat r)
 {
     if (vt_coordsize[0] > 3){
-	GL_MANGLE(glTexCoord4f)(s, t, r, 0);
+	GL_MANGLE_NAME(glTexCoord4f)(s, t, r, 0);
     } else {
         vt_coordsize[0] = 3;
         vt_current->coord[0].s = s;
@@ -433,7 +433,7 @@ GLvoid
 GL_MANGLE(glTexCoord2f)(GLfloat s, GLfloat t)
 {
     if (vt_coordsize[0] > 2){
-	GL_MANGLE(glTexCoord3f)(s, t, 0);
+	GL_MANGLE_NAME(glTexCoord3f)(s, t, 0);
     } else {
         vt_coordsize[0] = 2;
         vt_current->coord[0].s = s;
@@ -445,7 +445,7 @@ GLvoid
 GL_MANGLE(glTexCoord1f)(GLfloat s)
 {
     if (vt_coordsize[0] > 1){
-	GL_MANGLE(glTexCoord2f)(s, 0);
+	GL_MANGLE_NAME(glTexCoord2f)(s, 0);
     } else {
         vt_coordsize[0] = 1;
         vt_current->coord[0].s = s;
@@ -469,7 +469,7 @@ GL_MANGLE(glMultiTexCoord3f)(GLenum tex, GLfloat s, GLfloat t, GLfloat r)
 {
     GLuint ind = tex - GL_TEXTURE0;
     if (vt_coordsize[ind] > 3){
-	GL_MANGLE(glMultiTexCoord4f)(tex, s, t, r, 1.0);
+	GL_MANGLE_NAME(glMultiTexCoord4f)(tex, s, t, r, 1.0);
     } else {
         vt_coordsize[ind] = 3;
         vt_current->coord[ind].s = s;
@@ -483,7 +483,7 @@ GL_MANGLE(glMultiTexCoord2f)(GLenum tex, GLfloat s, GLfloat t)
 {
     GLuint ind = tex - GL_TEXTURE0;
     if (vt_coordsize[ind] > 2){
-	GL_MANGLE(glMultiTexCoord3f)(tex, s, t, 0.0);
+	GL_MANGLE_NAME(glMultiTexCoord3f)(tex, s, t, 0.0);
     } else {
         vt_coordsize[ind] = 2;
         vt_current->coord[ind].s = s;
@@ -496,7 +496,7 @@ GL_MANGLE(glMultiTexCoord1f)(GLenum tex, GLfloat s)
 {
     GLuint ind = tex - GL_TEXTURE0;
     if (vt_coordsize[ind] > 1){
-	GL_MANGLE(glMultiTexCoord2f)(tex, s, 0.0);
+	GL_MANGLE_NAME(glMultiTexCoord2f)(tex, s, 0.0);
     } else {
         vt_coordsize[ind] = 1;
         vt_current->coord[ind].s = s;
@@ -553,7 +553,7 @@ GLvoid
 GL_MANGLE(glColor3f)(GLfloat r, GLfloat g, GLfloat b)
 {
     if (vt_color0size > 3){
-	GL_MANGLE(glColor4f)(r, g, b, 1);
+	GL_MANGLE_NAME(glColor4f)(r, g, b, 1);
     } else {
         vt_color0size = 3;
         vt_ccurrent->cr0 = r;
@@ -584,14 +584,14 @@ GL_MANGLE(glColor4ub)(GLubyte r, GLubyte g, GLubyte b, GLubyte a)
 GLvoid
 GL_MANGLE(glColor4ubv)( const GLubyte *p )
 {
-	GL_MANGLE(glColor4ub)( p[0], p[1], p[2], p[3] );
+	GL_MANGLE_NAME(glColor4ub)( p[0], p[1], p[2], p[3] );
 }
 
 GLvoid
 GL_MANGLE(glColor3ub)(GLubyte r, GLubyte g, GLubyte b)
 {
     if (vt_color0size > 3){
-	GL_MANGLE(glColor4ub)(r, g, b, 255);
+	GL_MANGLE_NAME(glColor4ub)(r, g, b, 255);
     } else {
         vt_color0size = 3;
         vt_ccurrent->cr0 = r / 255.0f;// * ubtofloat;
@@ -783,7 +783,7 @@ rev=0;
             break;
 
         default:
-		LOGI("%x: uniplemented", vt_mode);
+		LOGI("%x: uniplemented\n", vt_mode);
  		//wes_gl->glDrawArrays(vt_mode, 0, vt_count);
             break;
         }
@@ -1412,16 +1412,16 @@ const GLubyte* GL_MANGLE(glGetString) (GLenum name)
 }
 
 void GL_MANGLE(glGetIntegerv) (GLenum pname, GLint *params)
-	{
+{
 	if( pname ==  0x84E2 ) // GL_MAX_TEXTURE_UNITS_ARB
 		pname = GL_MAX_TEXTURE_IMAGE_UNITS;
 	wes_gl->glGetIntegerv(pname, params);
-	}
+}
 
 void GL_MANGLE(glGetFloatv) (GLenum pname, GLfloat *params)
-	{
+{
 	wes_gl->glGetFloatv(pname, params);
-	}
+}
 
 void GL_MANGLE(glHint)(GLenum target, GLenum mode)
 {
@@ -1433,21 +1433,21 @@ void GL_MANGLE(glHint)(GLenum target, GLenum mode)
 }
 
 void GL_MANGLE(glReadPixels) (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid *pixels)
-	{
+{
 	if (format == GL_DEPTH_COMPONENT)
-		{
+	{
 		// OpenglEs 1.1 does not support reading depth buffer without an extension
 		memset(pixels, 0xff,4);
 		return;
-		}
+	}
 	wes_vertbuffer_flush();
 	wes_gl->glReadPixels(x,y,width,height,format,type,pixels);
-	}
+}
 /*
 void GL_MANGLE(glNormal3fv)( const GLfloat *v )
-	{
+{
 	glNormal3f( v[0], v[1], v[2] );
-	}
+}
 */
 /*
 void GL_MANGLE(glCullFace) (GLenum mode)
@@ -1465,36 +1465,36 @@ void GL_MANGLE(glPixelStorei) (GLenum pname, GLint param)
 
 
 void GL_MANGLE(glClear) (GLbitfield mask)
-	{
+{
 	FlushOnStateChange();
 	glEsImpl->glClear(mask);
-	}
+}
 
 
 GLboolean GL_MANGLE(glIsTexture)(GLuint texture)
-	{
+{
 	//FlushOnStateChange();
 	return glEsImpl->glIsTexture(texture);
-	}
+}
 /*
 void glDrawBuffer(GLenum mode)
-	{
-	}
+{
+}
 */
 void GL_MANGLE(glViewport) (GLint x, GLint y, GLsizei width, GLsizei height)
-	{
+{
 	FlushOnStateChange();
 	glEsImpl->glViewport(x,y,width,height);
-	}
+}
 /*
 void glBindTexture (GLenum target, GLuint texture)
-	{
+{
 	glEsImpl->glBindTexture(target, texture);
-	}
+}
 */
 /*
 void glTexParameterf (GLenum target, GLenum pname, GLfloat param)
-	{
+{
 	if (pname == 0x1004) { // GL_TEXTURE_BORDER_COLOR
 		return; // not supported by opengl es
 	}
@@ -1506,21 +1506,21 @@ void glTexParameterf (GLenum target, GLenum pname, GLfloat param)
 
 	FlushOnStateChange();
 	glEsImpl->glTexParameterf(target, pname,param);
-	}
+}
 
 void glTexParameterfv(	GLenum target, GLenum pname, const GLfloat *params)
-	{
+{
 	glTexParameterf(target, pname, params[0]);
-	}
+}
 */
 
 
 /*
 void glDeleteTextures( GLsizei n, const GLuint *textures )
-	{
+{
 	FlushOnStateChange();
 	glEsImpl->glDeleteTextures(n,textures);
-	}
+}
 
 
 
@@ -1649,8 +1649,8 @@ void GL_MANGLE(glBindBufferARB)( GLuint target, GLuint index )
 {
 //	if( index && !vbo_bkp_id && !skipnanogl )
 	//	FlushOnStateChange();
-	GL_MANGLE(glDisableClientState)( GL_COLOR_ARRAY );
-	GL_MANGLE(glColor4f)( 1,1,1,1 );
+	GL_MANGLE_NAME(glDisableClientState)( GL_COLOR_ARRAY );
+	GL_MANGLE_NAME(glColor4f)( 1,1,1,1 );
 
 	//if( index && !vbo_bkp_id && !skipnanogl )
 		//wes_vertbuffer_flush();

--- a/src/wes_fragment.c
+++ b/src/wes_fragment.c
@@ -1,5 +1,5 @@
 /*
-GL_MANGLE(gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
+gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
 Contact:    lachlan.ts@gmail.com
 Copyright (C) 2009  Lachlan Tychsen - Smith aka Adventus
 
@@ -24,10 +24,10 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "wes.h"
 #include "wes_state.h"
 #include "wes_shader.h"
-#include "wes.h"
 #include "wes_fragment.h"
 
-#define max(A, B)   ((A > B) ? A : B)
+#undef max
+inline static int max(int A, int B){return (A > B) ? A : B;}
 
 const char* frag_header = ""
 //						  "#define highp\n#define lowp\n#define mediump                         \n  "

--- a/src/wes_matrix.c
+++ b/src/wes_matrix.c
@@ -1,5 +1,5 @@
 /*
-GL_MANGLE(gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
+gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
 Contact:    lachlan.ts@gmail.com
 Copyright (C) 2009  Lachlan Tychsen - Smith aka Adventus
 
@@ -682,7 +682,7 @@ GL_MANGLE(glMultMatrixTransposef)(GLfloat *m)
     wes_vertbuffer_flush();
 
     wes_transpose4(m, tmp);
-    GL_MANGLE(glMultMatrixf)(tmp);
+    GL_MANGLE_NAME(glMultMatrixf)(tmp);
 }
 
 
@@ -881,7 +881,7 @@ GL_MANGLE(glOrthof)(float l, float r, float b, float t, float n, float f)
 
 GLvoid GL_MANGLE(glOrtho) (GLdouble left, GLdouble right, GLdouble bottom, GLdouble top, GLdouble zNear, GLdouble zFar)
 {
-	GL_MANGLE(glOrthof)(left,right,bottom,top, zNear,zFar);
+	GL_MANGLE_NAME(glOrthof)(left,right,bottom,top, zNear,zFar);
 }
 GLvoid
 GL_MANGLE(glPushMatrix)( void )
@@ -991,7 +991,7 @@ gluOrtho2D(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top)
 {
     wes_vertbuffer_flush();
 
-    GL_MANGLE(glOrthof)(left, right, bottom, top, -1, 1);
+    GL_MANGLE_NAME(glOrthof)(left, right, bottom, top, -1, 1);
 }
 
 GLvoid
@@ -1090,6 +1090,6 @@ gluLookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez,
 	tmp[10] = - forward[0] * m_current->data[2] - forward[1] * m_current->data[6] - forward[2] * m_current->data[10];
 	tmp[11] = - forward[0] * m_current->data[3] - forward[1] * m_current->data[7] - forward[2] * m_current->data[11];
     memcpy(m_current->data, tmp, 12 * sizeof(GLfloat));
-    GL_MANGLE(glTranslatef)(-eyex, -eyey, -eyez);
+    GL_MANGLE_NAME(glTranslatef)(-eyex, -eyey, -eyez);
 }
 #endif // WES_ENABLE_GLU

--- a/src/wes_shader.c
+++ b/src/wes_shader.c
@@ -1,5 +1,5 @@
 /*
-GL_MANGLE(gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
+gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
 Contact:    lachlan.ts@gmail.com
 Copyright (C) 2009  Lachlan Tychsen - Smith aka Adventus
 
@@ -425,7 +425,7 @@ wes_shader_error(GLuint ind)
     log = (char*) malloc(len + 1);
     memset(log, 0, len+1);
     wes_gl->glGetShaderInfoLog(ind, len, &i, log);
-    PRINT_ERROR("\nShader Error: %s", log);
+    PRINT_ERROR("Shader Error: %s\n", log);
     free(log);
 }
 
@@ -438,7 +438,7 @@ wes_program_error(GLuint ind)
     wes_gl->glGetProgramiv(ind, GL_INFO_LOG_LENGTH, &len);
     log = (char*) malloc(len * sizeof(char));
     wes_gl->glGetProgramInfoLog(ind, len, &i, log);
-    PRINT_ERROR("\nProgram Error: %s", log);
+    PRINT_ERROR("Program Error: %s\n", log);
     free(log);
 }
 
@@ -448,29 +448,28 @@ wes_shader_create(const char* data, GLenum type)
     GLuint  index;
     GLint   success;
 
-    LOGI("glCreateShader");
+    LOGI("glCreateShader\n");
     //Compile:
     index = wes_gl->glCreateShader(type);
     LOGI("glCreateShader, index = %d\n", index);
-	 wes_gl->glShaderSource(index, 1, &data, NULL);
+    wes_gl->glShaderSource(index, 1, &data, NULL);
     LOGI("glShaderSource\n");
-    
+
     wes_gl->glCompileShader(index);
     LOGI("glCompileShader\n");
-  
+
     //test status:
     wes_gl->glGetShaderiv(index, GL_COMPILE_STATUS, &success);
-	LOGI("glGetShaderiv\n");
+    LOGI("glGetShaderiv\n");
     if (success){
-	LOGI("shader success\n");
+        LOGI("shader success\n");
         return index;
     } else {
-	LOGI("shader error\n");
+    LOGI("shader error\n");
         wes_shader_error(index);
         wes_gl->glDeleteShader(index);
         return (0xFFFFFFFF);
     }
-
 }
 
 
@@ -728,32 +727,32 @@ wes_shader_init( void )
     sh_program_mod = GL_TRUE;
 
 #ifdef SHADER_FILE
-    //Load file into mem:
+	//Load file into mem:
 	file = fopen(SHADER_FILE, "rb");
-	LOGI("Before shader load");
+	LOGI("Before shader load\n");
 	if (!file){
-	    LOGE("Could not find file: %s", "WES.vsh");
+		LOGE("Could not find file: %s\n", SHADER_FILE);
 	}
- 	fseek(file, 0, SEEK_END);
+	fseek(file, 0, SEEK_END);
 	size = ftell(file);
 	fseek(file, 0, SEEK_SET);
 	data = (char*) malloc(size + 1);
 	if (!data){
-	    LOGE("Could not allocate: %i bytes", size + 1);
-    }
+		LOGE("Could not allocate: %i bytes\n", size + 1);
+	}
 	if (fread(data, sizeof(char), size, file) != size){
-        free(data);
-        LOGE("Could not read file: %s", "WES.vsh");
+		free(data);
+		LOGE("Could not read file: %s\n", SHADER_FILE);
 	}
 	data[size] = '\0';
 	fclose(file);
 
-	LOGI("before shader create");
-    sh_vertex = wes_shader_create(data, GL_VERTEX_SHADER);
-	LOGI("after shader create");
-    free(data);
+	LOGI("before shader create\n");
+	sh_vertex = wes_shader_create(data, GL_VERTEX_SHADER);
+	LOGI("after shader create\n");
+	free(data);
 #else
-	LOGI("Before shader load");
+	LOGI("Before shader load\n");
 
 	sh_vertex = wes_shader_create(wesShaderTestStr, GL_VERTEX_SHADER);
 	if(sh_vertex == 0xFFFFFFFF)
@@ -762,7 +761,7 @@ wes_shader_init( void )
 		sh_fallback = GL_TRUE;
 	}
 
-	LOGI("after shader create");
+	LOGI("after shader create\n");
 #endif
 }
 

--- a/src/wes_state.c
+++ b/src/wes_state.c
@@ -1,5 +1,5 @@
 /*
-GL_MANGLE(gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
+gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
 Contact:    lachlan.ts@gmail.com
 Copyright (C) 2009  Lachlan Tychsen - Smith aka Adventus
 
@@ -685,7 +685,7 @@ static GLvoid wes_setstate (GLenum e, GLboolean b)
             }
         default:
 			wes_setstate_old(e,b);
-			//LOGI("Change state: %x not implemented",e);
+			//LOGI("Change state: %x not implemented\n",e);
             break;
     }
         
@@ -720,7 +720,7 @@ static GLboolean wes_getstate (GLenum e)
         case GL_STENCIL_TEST: return GL_FALSE; // UNSUPPORTED!
         case GL_TEXTURE_2D: return u_progstate.uTexture[u_activetex].Enable;
 		default: 
-			// LOGI("glIsEnabled: %x not implemented",e);
+			// LOGI("glIsEnabled: %x not implemented\n",e);
 			return wes_gl->glIsEnabled(e);
             break;
     }
@@ -1167,7 +1167,7 @@ GL_MANGLE(glTexEnvi)(GLenum target, GLenum pname, GLint param)
 
 GLvoid GL_MANGLE(glTexEnvf) (GLenum target, GLenum pname, GLfloat param)
 {
-	GL_MANGLE(glTexEnvi)( target, pname, param );
+	GL_MANGLE_NAME(glTexEnvi)( target, pname, param );
 }
 
 GLvoid

--- a/src/wes_texture.c
+++ b/src/wes_texture.c
@@ -1,5 +1,5 @@
 /*
-GL_MANGLE(gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
+gl-wes-v2:  OpenGL 2.0 to OGLESv2.0 wrapper
 Contact:    lachlan.ts@gmail.com
 Copyright (C) 2009  Lachlan Tychsen - Smith aka Adventus
 
@@ -65,15 +65,15 @@ GLvoid
 GL_MANGLE(glTexParameterf) (GLenum target, GLenum pname, GLfloat param)
 {
 	if (pname == GL_TEXTURE_BORDER_COLOR)
-		{
+	{
 		return; // not supported by opengl es
-		}
+	}
 	if (    (pname == GL_TEXTURE_WRAP_S ||
 			 pname == GL_TEXTURE_WRAP_T) &&
 			 param == GL_CLAMP)
-			 {
-			 param = 0x812F;
-			 }
+	{
+		param = 0x812F;
+	}
 
 	wes_vertbuffer_flush();
 
@@ -83,7 +83,7 @@ GL_MANGLE(glTexParameterf) (GLenum target, GLenum pname, GLfloat param)
 GLvoid
 GL_MANGLE(glTexParameterfv)(	GLenum target, GLenum pname, const GLfloat *params)
 {
-	GL_MANGLE(glTexParameterf)(target, pname, params[0]);
+	GL_MANGLE_NAME(glTexParameterf)(target, pname, params[0]);
 }
 
 static GLvoid
@@ -202,12 +202,12 @@ void GL_MANGLE(glCopyTexImage2D)( GLenum target, GLint level, GLenum internalfor
 
 GLvoid GL_MANGLE(glTexImage1D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLint border, GLenum format, GLenum type, const GLvoid *pixels)
 {
-    GL_MANGLE(glTexImage2D)(GL_TEXTURE_2D, level, internalformat,  width, 1, border, format, type, pixels);
+    GL_MANGLE_NAME(glTexImage2D)(GL_TEXTURE_2D, level, internalformat,  width, 1, border, format, type, pixels);
 }
 
 GLvoid GL_MANGLE(glTexImage3D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels)
 {
-    GL_MANGLE(glTexImage2D)(GL_TEXTURE_2D, level, internalformat,  width, height, border, format, type, pixels);
+    GL_MANGLE_NAME(glTexImage2D)(GL_TEXTURE_2D, level, internalformat,  width, height, border, format, type, pixels);
 }
 
 GLvoid GL_MANGLE(glTexSubImage1D)( GLenum target, GLint level, GLint xoffset, GLsizei width, GLenum format, GLenum type, const GLvoid *pixels )
@@ -263,7 +263,7 @@ gluBuild2DMipmaps(GLenum target, GLint components, GLsizei width, GLsizei height
         return;
     }
 
-    GL_MANGLE(glTexImage2D)(target, 0, format, width, height, 0, format, type, pixels);
+    GL_MANGLE_NAME(glTexImage2D)(target, 0, format, width, height, 0, format, type, pixels);
 
     data = (char*) malloc(width * height * byteperpixel);
     memcpy(data, pixels, width * height * byteperpixel);
@@ -274,7 +274,7 @@ gluBuild2DMipmaps(GLenum target, GLint components, GLsizei width, GLsizei height
         if (height == 0) height = 1;
         newdata = (char*) malloc(width * height * byteperpixel);
         wes_halveimage(width, height, byteperpixel, data, newdata);
-	GL_MANGLE(glTexImage2D)(target, i++, format, width, height, 0, format, type, newdata);
+	GL_MANGLE_NAME(glTexImage2D)(target, i++, format, width, height, 0, format, type, newdata);
         free(data);
         data = newdata;
     }


### PR DESCRIPTION
Basically the same as https://github.com/FWGS/nanogl/pull/8

- `APIENTRY` to all gl functions, exported and imported (`wes_gl->glShaderSource` was crashing)
- Also moved new lines to the end of log strings
- Remove erroneous `GL_MANGLE(` from file headers introduced in https://github.com/FWGS/gl-wes-v2/commit/7033c4ec8365825d95e508e1884b7b90d68d2ef8
- get rid of `max` macro

Tested with Mesa 25.2.0-rc1. Rendering still kinda broken on new engine